### PR TITLE
fix: handle empty post URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "omaro"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "omaro"
 description = "TUI for lobste.rs. Browse posts and comments from the comfort of your terminal"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 repository = "https://github.com/rolv-apneseth/omaro"
 homepage = "https://github.com/rolv-apneseth/omaro"

--- a/src/app/handle_posts.rs
+++ b/src/app/handle_posts.rs
@@ -74,7 +74,16 @@ impl App {
             "trying to open post out of bounds"
         );
 
-        open::that_detached(&self.posts[index].url).context("failed to launch link opener")?;
+        let Some(post) = self.current_post() else {
+            return Ok(());
+        };
+
+        if post.url.is_empty() {
+            self.open_post_comments()?;
+        } else {
+            open::that_detached(&post.url).context("failed to launch link opener")?;
+        };
+
         self.mark_post_read(index, tx)
     }
 


### PR DESCRIPTION
Previously, information type posts, which only have a link to the post itself on `lobste.rs` and not an external URL, would not open. With this fix, just open the URL to the post instead if the external URL is empty.