### PR TITLE
feat: add options to mark post as read when opening or previewing its comments

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,50 @@
+name: CD - binaries # Build binaries
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  upload-binaries:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'rolv-apneseth'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-apple-darwin
+          - target: aarch64-pc-windows-msvc
+          - target: x86_64-pc-windows-msvc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: clipvault
+          target: ${{ matrix.target }}
+          tar: all
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'rolv-apneseth' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          # Allow this workflow to trigger workflows (i.e. the binaries workflow)
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'rolv-apneseth' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -56,23 +56,20 @@ by replacing the icons used. More details below in the configuration section.
 
 ## Installation
 
-### Cargo
-
 ```bash
 cargo install omaro --locked
+```
+
+Or, directly from source:
+
+```bash
+cargo install --git https://github.com/rolv-apneseth/omaro --locked
 ```
 
 ### AUR
 
 ```bash
 paru -S omaro
-```
-
-### Manual / Build from source
-
-```bash
-git clone https://github.com/Rolv-Apneseth/omaro.git
-cargo install --path ./omaro --locked
 ```
 
 ## Configuration

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -1,5 +1,9 @@
 # Possible modes: hottest | newest | active
 default_mode = "hottest"
+# If true, opening the link for a post's comments will mark the post as read
+opening_comments_marks_posts_read = true
+# If true, previewing the comments for a post will mark the post as read
+previewing_comments_marks_posts_read = true
 
 # Borders around the TUI, and around popups
 [ui.borders]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,49 @@
+[workspace]
+git_release_name = "{{ package }} v{{ version }}"
+semver_check = false
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"""
+
+body = """
+
+## [{{ version }}]\
+    {%- if release_link -%}\
+        ({{ release_link }})\
+    {% endif %} \
+    - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+
+    {% for commit in commits %}
+        {%- if commit.scope -%}
+            - *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}\
+                {{ commit.message }}\
+                {%- if commit.links %} \
+                    ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%})\
+                {% endif %}
+        {% else -%}
+            - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+        {% endif -%}
+    {% endfor -%}
+{% endfor %}
+"""
+
+commit_parsers = [
+  { message = "^feat", group = "features" },
+  { message = "^fix", group = "fixes" },
+  { message = "^security", group = "security" },
+  { message = "^perf", group = "performance" },
+  { message = "^refactor", group = "changes" },
+  { message = "^test", group = "testing" },
+  { message = "^revert", group = "revert" },
+  { message = "^.*", skip = true },
+]

--- a/src/app/handle_events.rs
+++ b/src/app/handle_events.rs
@@ -54,11 +54,15 @@ impl App {
                 return Ok(());
             }
             KeyCode::Char('K') => {
-                if !self.posts.is_empty() {
-                    self.load_post_comments(tx_details)?;
-                    self.comments_list_state.select(Some(0));
+                if let Some(index) = self.posts_list_state.selected()
+                    && !self.posts.is_empty()
+                {
                     self.show_details_popup = !self.show_details_popup;
-                }
+                    if self.show_details_popup {
+                        self.load_post_comments(index, tx_details, tx_db)?;
+                        self.comments_list_state.select(Some(0));
+                    }
+                };
             }
 
             // FUNCTIONALITY
@@ -70,7 +74,9 @@ impl App {
                 }
             }
             KeyCode::Char('c') => {
-                self.open_post_comments()?;
+                if let Some(selected) = self.posts_list_state.selected() {
+                    self.open_post_comments(selected, tx_db)?;
+                }
             }
 
             KeyCode::Char('r') => {
@@ -86,7 +92,11 @@ impl App {
 
             KeyCode::Char('R') | KeyCode::F(5) => {
                 if self.show_details_popup {
-                    self.load_post_comments(tx_details)?;
+                    let index = self
+                        .posts_list_state
+                        .selected()
+                        .expect("in details popup - relevant post should be selected");
+                    self.load_post_comments(index, tx_details, tx_db)?;
                 } else {
                     self.load_posts(tx_posts)?;
                 }
@@ -174,13 +184,17 @@ impl App {
                             }
                         }
                         MouseButton::Right => {
-                            if !self.posts.is_empty() {
-                                self.load_post_comments(tx_details)?;
+                            if let Some(index) = self.posts_list_state.selected()
+                                && !self.posts.is_empty()
+                            {
                                 self.show_details_popup = !self.show_details_popup;
-                                self.comments_list_state.select(Some(0));
-                            }
+                                if self.show_details_popup {
+                                    self.load_post_comments(index, tx_details, tx_db)?;
+                                    self.comments_list_state.select(Some(0));
+                                }
+                            };
                         }
-                        MouseButton::Middle => self.open_post_comments()?,
+                        MouseButton::Middle => self.open_post_comments(i, tx_db)?,
                     };
                 }
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,12 +16,31 @@ pub static DEFAULT_CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
         .join("config.toml")
 });
 
-#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct Config {
     #[serde(default)]
     pub default_mode: Mode,
+    #[serde(default = "_default_true")]
+    pub opening_comments_marks_posts_read: bool,
+    #[serde(default = "_default_true")]
+    pub previewing_comments_marks_posts_read: bool,
 
     pub ui: UiConfig,
+}
+
+fn _default_true() -> bool {
+    true
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            default_mode: Default::default(),
+            ui: UiConfig::default(),
+            opening_comments_marks_posts_read: true,
+            previewing_comments_marks_posts_read: true,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]


### PR DESCRIPTION
Closes #4

Added two options, which are enabled by default, to mark a post as read if you open the link to its comments or preview it's comments within `omaro`.

Also adding a `release-plz` workflow, and a workflow to build binaries for the releases.